### PR TITLE
Finish addons chapter

### DIFF
--- a/src/components/Task.js
+++ b/src/components/Task.js
@@ -28,6 +28,7 @@ export default function Task({
           value={title}
           readOnly={true}
           placeholder="Input title"
+          style={{ textOverflow: "ellipsis" }}
         />
       </div>
 

--- a/src/components/Task.stories.js
+++ b/src/components/Task.stories.js
@@ -34,3 +34,17 @@ Archived.args = {
     state: "TASK_ARCHIVED",
   },
 };
+
+const longTitleString = `This task's name is absurdly large. \
+In fact, I think if I keep going I might end up with content \
+overflow. What will happen? The star that represents a pinned \
+task could have text overlapping. The text could cut-off abruptly \
+when it reaches the star. I hope not!`;
+
+export const LongTitle = Template.bind({});
+LongTitle.args = {
+  task: {
+    ...Default.args.task,
+    title: longTitleString,
+  },
+};


### PR DESCRIPTION
### 🚧  Changes

- Truncated overflowing `Task` title
- Added long story title for `Task`